### PR TITLE
Add websocket service and Docker config to websocket folder (/websocket)

### DIFF
--- a/websocket/Dockerfile
+++ b/websocket/Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+  PYTHONUNBUFFERED=1
+
+# Install python deps first for better layer caching
+COPY requirements.txt /app/requirements.txt
+RUN pip install --no-cache-dir --upgrade pip \
+  && pip install --no-cache-dir -r /app/requirements.txt
+
+# Copy service code
+COPY . /app
+
+EXPOSE 8590
+
+# Run the websocket service
+CMD ["python", "websocket.py"]

--- a/websocket/docker-compose.yml
+++ b/websocket/docker-compose.yml
@@ -1,0 +1,10 @@
+version: "3.8"
+
+services:
+  websocket:
+    image: websocket_open
+    build:
+      context: .
+    ports:
+    - "8590:8590"
+    restart: unless-stopped

--- a/websocket/requirements.txt
+++ b/websocket/requirements.txt
@@ -1,0 +1,3 @@
+flask==3.0.3
+flask_socketio==5.6.1
+eventlet==0.36.1

--- a/websocket/websocket.py
+++ b/websocket/websocket.py
@@ -1,0 +1,23 @@
+import eventlet
+eventlet.monkey_patch()
+
+from flask import Flask, jsonify
+from flask_socketio import SocketIO
+
+app = Flask(__name__)
+socketio = SocketIO(app, cors_allowed_origins="*")
+
+
+@app.get("/health")
+def health():
+    return jsonify({"ok": True, "service": "websocket"}), 200
+
+
+@app.get("/")
+def index():
+    return jsonify({"message": "websocket service running"}), 200
+
+
+if __name__ == "__main__":
+    # Keep this aligned with `websocket/docker-compose.yml`
+    socketio.run(app, host="0.0.0.0", port=8590)


### PR DESCRIPTION
Introduce a new Flask + Flask-SocketIO websocket service with eventlet. Adds websocket.py (basic health and index endpoints, socketio run on 0.0.0.0:8590), pinned requirements.txt, a Dockerfile that installs deps and exposes port 8590, and a docker-compose.yml to build/run the service. This provides a containerized websocket endpoint for local/dev usage.