### PR TITLE
Add disconnect handler and improve logging

### DIFF
--- a/websocket/docker-compose.yml
+++ b/websocket/docker-compose.yml
@@ -1,10 +1,9 @@
 version: "3.8"
-
 services:
   websocket:
     image: websocket_open
     build:
       context: .
     ports:
-    - "8590:8590"
+      - "8590:8590"
     restart: unless-stopped

--- a/websocket/websocket.py
+++ b/websocket/websocket.py
@@ -1,21 +1,56 @@
 import eventlet
 eventlet.monkey_patch()
 
-from flask import Flask, jsonify
+from flask import Flask, jsonify, request
 from flask_socketio import SocketIO
 
-app = Flask(__name__)
-socketio = SocketIO(app, cors_allowed_origins="*")
+import time
 
+app = Flask(__name__)
+socketio = SocketIO(app, cors_allowed_origins="*", async_mode="eventlet")
 
 @app.get("/health")
 def health():
-    return jsonify({"ok": True, "service": "websocket"}), 200
+    # Get current server time
+    server_time = time.strftime("%Y-%m-%d %H:%M:%S", time.gmtime())
+    # Try to get client IP
+    client_ip = request.headers.get("X-Forwarded-For", request.remote_addr)
+    # Latency: if client sends ?ping=timestamp, return round-trip
+    ping = request.args.get("ping")
+    latency = None
+    if ping:
+        try:
+            latency = time.time() - float(ping)
+        except Exception:
+            latency = None
+    resp = {
+        "ok": True,
+        "service": "websocket",
+        "server_time_utc": server_time,
+        "client_ip": client_ip,
+        "latency_seconds": latency,
+        "info": "Send ?ping=<epoch_seconds> to measure latency."
+    }
+    return jsonify(resp), 200
 
 
 @app.get("/")
 def index():
     return jsonify({"message": "websocket service running"}), 200
+
+@socketio.on('connect')
+def handle_connect():
+    print(f"Client connected: {request.sid}")
+    # Send a welcome message or initial data
+    socketio.emit('live_update', {'msg': 'Welcome! Live data will stream here.'}, room=request.sid)
+
+@socketio.on('get_live_info')
+def handle_live_info(data=None):
+    response = {"info": "This is live info from the server!"}
+    socketio.emit('live_update', response, room=request.sid)
+    # This could fetch live info from your app, DB, etc.
+    data = {"info": "This is live info from the server!"}
+    socketio.emit('live_update', data, room=request.sid)
 
 
 if __name__ == "__main__":

--- a/websocket/websocket.py
+++ b/websocket/websocket.py
@@ -38,20 +38,21 @@ def health():
 def index():
     return jsonify({"message": "websocket service running"}), 200
 
+
 @socketio.on('connect')
 def handle_connect():
-    print(f"Client connected: {request.sid}")
-    # Send a welcome message or initial data
+    print(f"[SERVER] Client connected: {request.sid}")
     socketio.emit('live_update', {'msg': 'Welcome! Live data will stream here.'}, room=request.sid)
+
+
+@socketio.on('disconnect')
+def handle_disconnect():
+    print(f"[SERVER] Client disconnected: {request.sid}")
 
 @socketio.on('get_live_info')
 def handle_live_info(data=None):
     response = {"info": "This is live info from the server!"}
     socketio.emit('live_update', response, room=request.sid)
-    # This could fetch live info from your app, DB, etc.
-    data = {"info": "This is live info from the server!"}
-    socketio.emit('live_update', data, room=request.sid)
-
 
 if __name__ == "__main__":
     # Keep this aligned with `websocket/docker-compose.yml`


### PR DESCRIPTION
Update websocket handlers to improve logging and tidy up live info emission. Change connect log to include a [SERVER] prefix, add a disconnect handler that logs when clients disconnect, and simplify handle_live_info to emit a single response (removed duplicated/commented code). Minor whitespace/formatting cleanup.
