### PR TITLE
Enhance database migration and management scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ instance/volumes/
 instance/data.json
 instance/data.json.*.bak
 instance/data/jokes.json
+*user_management*.db

--- a/README.md
+++ b/README.md
@@ -223,43 +223,68 @@ The key files and directories in this project are in these online articles.
 
 ## Database Management Workflow with Scripts
 
-If you are working with the database, follow the below procedure to safely interact with the remote DB while applying changes locally. Certain scripts require flask to be running while others don't, so follow the instructions that the scripts provide.
+Production runs on **MySQL (AWS RDS)**; local development runs on SQLite. Data moves
+between them over the admin-only `/api/export/*` endpoints, so **both sides must be
+running the same code** before you migrate.
 
-Note, steps 1,2,3,5 are on your development (LOCAL) server. You need to update your .env on development server and be sure all PRs are completed, pulled, and tested before you start pushing to production.
+Critically: step 4 runs `db_init.py` on production, which does a `drop_all()`. Anything
+not covered by the export/import endpoints is destroyed there and never comes back. The
+scripts now reconcile every table against `/api/export/counts` and exit non-zero on any
+shortfall -- do not ignore that.
 
-0. Be sure ADMIN_PASSWORD is set in .env.  You will need a venv for the python scripts.
+0. Be sure `ADMIN_UID` / `ADMIN_PASSWORD` in `.env` are the **production** admin
+   credentials. You will need a venv for the python scripts.
 
-1. Initialize your local DB with clean data. For example, this would be good to see that a schema update works correctly.
+1. Initialize your local DB with clean data, to confirm the new schema builds:
    ```bash
    python scripts/db_init.py
    ```
 
-2. Pull the database content from the remote DB onto your local machine. This allows you to work with real data and test that real data works with your local changes.
+2. Pull production data to local. This fetches every table, then compares local row
+   counts against production table by table:
    ```bash
    python scripts/db_migrate-prod2sqlite.py
    ```
+   A non-zero exit means the pull was incomplete. Fix it before going further -- pushing
+   an incomplete pull back to production deletes the difference.
 
 3. TEST TEST TEST! Make sure your changes work correctly with the local DB.
 
-4. Now go onto the remote DB and back up the db using `cp sqlite.db backups/sqlite_year-month-day.db` in the volumes directory of the flask directory on cockpit. Then, run `git pull` to ensure that flask has been updated with the latest code. Then, run `python scripts/db_init.py` again to ensure that the remote DB schema is up to date with the latest code.
+4. On production (cockpit, `open/flask`):
+   - Update code: `git pull`  (this must include the `/api/export/counts` endpoint and the
+     leaderboard / skill-snapshot export endpoints, or step 5 cannot verify itself)
+   - Restart flask so the new endpoints are live
+   - Update schema: `python scripts/db_init.py`
 
-5. Once you are satisfied with your changes, push the local DB content to the remote DB. This requires authentication, so you need to replace the ADMIN_PASSWORD in the .env file of "flask" with the production admin password.
+5. Push local data back to production:
    ```bash
    python scripts/db_restore-sqlite2prod.py
    ```
+   This re-reads production's counts afterwards and reports any table that did not fully
+   transfer. Keep your local copy until it reports a clean reconciliation -- until then
+   your local database is the only complete copy of that data.
+
+### Tables covered by the migration
+
+`sections`, `users`, `topics`, `microblogs`, `posts`, `classrooms`, `feedback`, `study`,
+`personas`, `user_personas`, `leaderboard`, `elementary_leaderboard`, `skill_snapshots`,
+plus the `user_sections` and `classroom_students` association rows.
+
+**Adding a new model?** It must be added in three places or its data is lost on the next
+migration: `MIGRATED_MODELS` plus export/import endpoints in
+`api/data_export_import_api.py`, `EXPORT_ENDPOINTS` + a loader in
+`scripts/db_migrate-prod2sqlite.py`, and `IMPORT_ENDPOINTS` + a reader in
+`scripts/db_restore-sqlite2prod.py`. `/api/export/counts` is what catches the omission.
 
 ### Condensed DB/Schema update simple steps
 *(a copy of what's above, just condensed)*
 
 1. Initialize local DB: `python scripts/db_init.py`
 
-2. Pull production data to local: `python scripts/db_migrate-prod2sqlite.py`
+2. Pull production data to local: `python scripts/db_migrate-prod2sqlite.py` (must exit 0)
 
 3. Test your changes locally
 
-4. On production server (in cockpit):
-   - Backup DB in volumes directory: `cp sqlite.db backups/sqlite_year-month-day.db`
-   - Update code: `git pull`
-   - Update schema: `python scripts/db_init.py`
+4. On production: `git pull`, restart flask, then `python scripts/db_init.py`
 
-5. Push local changes to production: `python scripts/db_restore-sqlite2prod.py` (Requires admin password from production in .env)
+5. Push local changes to production: `python scripts/db_restore-sqlite2prod.py` (must exit 0)

--- a/api/data_export_import_api.py
+++ b/api/data_export_import_api.py
@@ -17,9 +17,73 @@ from model.classroom import Classroom
 from model.feedback import Feedback
 from model.study import Study
 from model.persona import Persona, UserPersona
+from model.leaderboard import ScoreCounterEvent, ElementaryLeaderboardEvent
+from model.skill_snapshot import SkillSnapshot
 
 data_export_import_api = Blueprint('data_export_import_api', __name__, url_prefix='/api/export')
 api = Api(data_export_import_api)
+
+
+def _parse_dt(value):
+    """Parse an ISO-8601 timestamp emitted by a model read(); None if unusable."""
+    if not value:
+        return None
+    from datetime import datetime
+    try:
+        return datetime.fromisoformat(str(value).replace('Z', '+00:00'))
+    except (TypeError, ValueError):
+        return None
+
+
+# Every persisted model, keyed by the data type name used across the migration
+# scripts. Kept in one place so /counts, the exporters and the importers cannot
+# drift apart -- a missing entry here is what silently loses a table.
+MIGRATED_MODELS = {
+    'sections':                 Section,
+    'users':                    User,
+    'topics':                   Topic,
+    'microblogs':               MicroBlog,
+    'posts':                    Post,
+    'classrooms':               Classroom,
+    'feedback':                 Feedback,
+    'study':                    Study,
+    'personas':                 Persona,
+    'user_personas':            UserPersona,
+    'leaderboard':              ScoreCounterEvent,
+    'elementary_leaderboard':   ElementaryLeaderboardEvent,
+    'skill_snapshots':          SkillSnapshot,
+}
+
+
+class ExportCounts(Resource):
+    """Row counts for every migrated table, used to verify a migration moved everything."""
+
+    @token_required()
+    def get(self):
+        current_user = g.current_user
+        if current_user.role != 'Admin':
+            return {'message': 'Admin privileges required'}, 403
+
+        counts = {}
+        for name, model in MIGRATED_MODELS.items():
+            try:
+                counts[name] = model.query.count()
+            except Exception as e:
+                counts[name] = f'error: {e}'
+
+        # Association tables have no model class of their own.
+        try:
+            from model.classroom import classroom_student
+            counts['classroom_students'] = db.session.query(classroom_student).count()
+        except Exception as e:
+            counts['classroom_students'] = f'error: {e}'
+        try:
+            from model.user import UserSection
+            counts['user_sections'] = UserSection.query.count()
+        except Exception as e:
+            counts['user_sections'] = f'error: {e}'
+
+        return jsonify({'counts': counts})
 
 
 class ExportAllData(Resource):
@@ -54,6 +118,9 @@ class ExportAllData(Resource):
                 'study': self._export_study(),
                 'personas': self._export_personas(),
                 'user_personas': self._export_user_personas(),
+                'leaderboard': self._export_event_table(ScoreCounterEvent),
+                'elementary_leaderboard': self._export_event_table(ElementaryLeaderboardEvent),
+                'skill_snapshots': self._export_skill_snapshots(),
             }
 
             # Add metadata
@@ -155,6 +222,27 @@ class ExportAllData(Resource):
         personas = Persona.query.all()
         return [p.read() for p in personas]
 
+    def _export_event_table(self, model):
+        """Export one of the leaderboard event tables"""
+        return [
+            {
+                'id':        event.id,
+                'userUid':   event.user.uid if event.user else None,
+                'payload':   event._payload or {},
+                'timestamp': event._timestamp.isoformat() if event._timestamp else None,
+            }
+            for event in model.query.order_by(model.id).all()
+        ]
+
+    def _export_skill_snapshots(self):
+        """Export all skill snapshots"""
+        result = []
+        for snapshot in SkillSnapshot.query.order_by(SkillSnapshot.id).all():
+            data = snapshot.read()
+            data['userUid'] = snapshot.user.uid if snapshot.user else None
+            result.append(data)
+        return result
+
     def _export_user_personas(self):
         """Export user-persona associations"""
         user_personas = UserPersona.query.all()
@@ -217,6 +305,9 @@ class ImportAllData(Resource):
             'study': {'imported': 0, 'failed': 0, 'errors': []},
             'personas': {'imported': 0, 'failed': 0, 'errors': []},
             'user_personas': {'imported': 0, 'failed': 0, 'errors': []},
+            'leaderboard': {'imported': 0, 'failed': 0, 'errors': []},
+            'elementary_leaderboard': {'imported': 0, 'failed': 0, 'errors': []},
+            'skill_snapshots': {'imported': 0, 'failed': 0, 'errors': []},
         }
 
         try:
@@ -260,6 +351,19 @@ class ImportAllData(Resource):
             # 10. Study (depends on users)
             if 'study' in data:
                 results['study'] = self._import_study(data['study'])
+
+            # 11. Leaderboard events (depend on users, but tolerate orphans)
+            if 'leaderboard' in data:
+                results['leaderboard'] = self._import_leaderboard(data['leaderboard'])
+
+            if 'elementary_leaderboard' in data:
+                results['elementary_leaderboard'] = self._import_elementary_leaderboard(
+                    data['elementary_leaderboard']
+                )
+
+            # 12. Skill snapshots (depend on users)
+            if 'skill_snapshots' in data:
+                results['skill_snapshots'] = self._import_skill_snapshots(data['skill_snapshots'])
 
             return jsonify({
                 'message': 'Import completed',
@@ -320,7 +424,8 @@ class ImportAllData(Resource):
                     grade_data=user_data.get('grade_data') or user_data.get('gradeData'),
                     ap_exam=user_data.get('ap_exam') or user_data.get('apExam'),
                     school=user_data.get('school'),
-                    classes=user_data.get('class') or user_data.get('_class')
+                    classes=user_data.get('class') or user_data.get('_class'),
+                    game_profile=user_data.get('game_profile') or user_data.get('gameProfile')
                 )
 
                 # Set email via property (not a constructor param)
@@ -631,6 +736,83 @@ class ImportAllData(Resource):
 
         return {'imported': imported, 'failed': failed, 'errors': errors}
 
+    def _import_events(self, events_data, model, label):
+        """Import leaderboard events, preserving the original timestamp."""
+        imported = 0
+        failed = 0
+        errors = []
+
+        for event_data in events_data:
+            try:
+                user_uid = event_data.get('userUid')
+                user = User.query.filter_by(_uid=user_uid).first() if user_uid else None
+
+                # user_id is nullable on both event tables: an event whose author
+                # is gone is still real history and must not be dropped.
+                event = model(
+                    payload=event_data.get('payload') or {},
+                    user_id=user.id if user else None,
+                )
+                timestamp = _parse_dt(event_data.get('timestamp'))
+                if timestamp:
+                    event._timestamp = timestamp
+
+                db.session.add(event)
+                db.session.commit()
+                imported += 1
+            except Exception as e:
+                db.session.rollback()
+                failed += 1
+                errors.append(f"{label}: {str(e)}")
+
+        return {'imported': imported, 'failed': failed, 'errors': errors}
+
+    def _import_leaderboard(self, events_data):
+        """Import SCORE_COUNTER leaderboard events"""
+        return self._import_events(events_data, ScoreCounterEvent, 'Leaderboard')
+
+    def _import_elementary_leaderboard(self, events_data):
+        """Import elementary leaderboard events"""
+        return self._import_events(events_data, ElementaryLeaderboardEvent, 'ElementaryLeaderboard')
+
+    def _import_skill_snapshots(self, snapshots_data):
+        """Import skill snapshots"""
+        imported = 0
+        failed = 0
+        errors = []
+
+        for snapshot_data in snapshots_data:
+            try:
+                user_uid = snapshot_data.get('userUid')
+                user = User.query.filter_by(_uid=user_uid).first() if user_uid else None
+                if not user:
+                    # user_id is NOT NULL here, so an orphan snapshot cannot be stored.
+                    failed += 1
+                    errors.append(f"SkillSnapshot: no user for uid {user_uid!r}")
+                    continue
+
+                snapshot = SkillSnapshot(
+                    user_id=user.id,
+                    project_name=snapshot_data.get('project_name'),
+                    coding_ability=snapshot_data.get('coding_ability'),
+                    collaboration=snapshot_data.get('collaboration'),
+                    problem_solving=snapshot_data.get('problem_solving'),
+                    initiative=snapshot_data.get('initiative'),
+                )
+                snapshot_date = _parse_dt(snapshot_data.get('snapshot_date'))
+                if snapshot_date:
+                    snapshot.snapshot_date = snapshot_date
+
+                db.session.add(snapshot)
+                db.session.commit()
+                imported += 1
+            except Exception as e:
+                db.session.rollback()
+                failed += 1
+                errors.append(f"SkillSnapshot: {str(e)}")
+
+        return {'imported': imported, 'failed': failed, 'errors': errors}
+
 
 # Individual export endpoints for chunked exports
 class ExportSections(Resource):
@@ -859,6 +1041,82 @@ class ExportUserPersonas(Resource):
         })
 
 
+def _export_events(model, key):
+    """Paginated export shared by the two leaderboard event tables."""
+    page = request.args.get('page', 1, type=int)
+    per_page = request.args.get('per_page', 50, type=int)
+
+    pagination = model.query.order_by(model.id).paginate(page=page, per_page=per_page, error_out=False)
+
+    result = []
+    for event in pagination.items:
+        result.append({
+            'id':        event.id,
+            'userUid':   event.user.uid if event.user else None,
+            'payload':   event._payload or {},
+            'timestamp': event._timestamp.isoformat() if event._timestamp else None,
+        })
+
+    return jsonify({
+        key: result,
+        'count': len(result),
+        'total': pagination.total,
+        'page': page,
+        'per_page': per_page,
+        'has_next': pagination.has_next,
+        'has_prev': pagination.has_prev
+    })
+
+
+class ExportLeaderboard(Resource):
+    """Export the SCORE_COUNTER leaderboard events ('leaderboard' table)."""
+    @token_required()
+    def get(self):
+        if g.current_user.role != 'Admin':
+            return {'message': 'Admin privileges required'}, 403
+        return _export_events(ScoreCounterEvent, 'leaderboard')
+
+
+class ExportElementaryLeaderboard(Resource):
+    """Export the elementary leaderboard events."""
+    @token_required()
+    def get(self):
+        if g.current_user.role != 'Admin':
+            return {'message': 'Admin privileges required'}, 403
+        return _export_events(ElementaryLeaderboardEvent, 'elementary_leaderboard')
+
+
+class ExportSkillSnapshots(Resource):
+    """Export skill snapshots."""
+    @token_required()
+    def get(self):
+        if g.current_user.role != 'Admin':
+            return {'message': 'Admin privileges required'}, 403
+
+        page = request.args.get('page', 1, type=int)
+        per_page = request.args.get('per_page', 50, type=int)
+
+        pagination = SkillSnapshot.query.order_by(SkillSnapshot.id).paginate(
+            page=page, per_page=per_page, error_out=False
+        )
+
+        result = []
+        for snapshot in pagination.items:
+            data = snapshot.read()
+            data['userUid'] = snapshot.user.uid if snapshot.user else None
+            result.append(data)
+
+        return jsonify({
+            'skill_snapshots': result,
+            'count': len(result),
+            'total': pagination.total,
+            'page': page,
+            'per_page': per_page,
+            'has_next': pagination.has_next,
+            'has_prev': pagination.has_prev
+        })
+
+
 # ============ Chunked Import Endpoints ============
 # These allow importing data one type at a time to avoid timeouts
 
@@ -1062,9 +1320,66 @@ class ImportUserPersonas(Resource):
             return {'message': f'Import failed: {str(e)}'}, 500
 
 
+class ImportLeaderboard(Resource):
+    """Import SCORE_COUNTER leaderboard events only"""
+    @token_required()
+    def post(self):
+        if g.current_user.role != 'Admin':
+            return {'message': 'Admin privileges required'}, 403
+
+        data = request.get_json()
+        try:
+            result = ImportAllData()._import_leaderboard(data.get('leaderboard', []))
+            db.session.commit()
+            return jsonify({'leaderboard': result, 'message': 'Leaderboard import complete'})
+        except Exception as e:
+            db.session.rollback()
+            return {'message': f'Import failed: {str(e)}'}, 500
+
+
+class ImportElementaryLeaderboard(Resource):
+    """Import elementary leaderboard events only"""
+    @token_required()
+    def post(self):
+        if g.current_user.role != 'Admin':
+            return {'message': 'Admin privileges required'}, 403
+
+        data = request.get_json()
+        try:
+            result = ImportAllData()._import_elementary_leaderboard(
+                data.get('elementary_leaderboard', [])
+            )
+            db.session.commit()
+            return jsonify({
+                'elementary_leaderboard': result,
+                'message': 'Elementary leaderboard import complete',
+            })
+        except Exception as e:
+            db.session.rollback()
+            return {'message': f'Import failed: {str(e)}'}, 500
+
+
+class ImportSkillSnapshots(Resource):
+    """Import skill snapshots only"""
+    @token_required()
+    def post(self):
+        if g.current_user.role != 'Admin':
+            return {'message': 'Admin privileges required'}, 403
+
+        data = request.get_json()
+        try:
+            result = ImportAllData()._import_skill_snapshots(data.get('skill_snapshots', []))
+            db.session.commit()
+            return jsonify({'skill_snapshots': result, 'message': 'Skill snapshots import complete'})
+        except Exception as e:
+            db.session.rollback()
+            return {'message': f'Import failed: {str(e)}'}, 500
+
+
 # Register endpoints
 api.add_resource(ExportAllData, '/all')
 api.add_resource(ImportAllData, '/import')
+api.add_resource(ExportCounts, '/counts')
 
 # Chunked export endpoints
 api.add_resource(ExportSections, '/sections')
@@ -1077,6 +1392,9 @@ api.add_resource(ExportFeedback, '/feedback')
 api.add_resource(ExportStudy, '/study')
 api.add_resource(ExportPersonas, '/personas')
 api.add_resource(ExportUserPersonas, '/user_personas')
+api.add_resource(ExportLeaderboard, '/leaderboard')
+api.add_resource(ExportElementaryLeaderboard, '/elementary_leaderboard')
+api.add_resource(ExportSkillSnapshots, '/skill_snapshots')
 
 # Chunked import endpoints (POST to same paths as export)
 api.add_resource(ImportSections, '/import/sections')
@@ -1089,3 +1407,6 @@ api.add_resource(ImportFeedback, '/import/feedback')
 api.add_resource(ImportStudy, '/import/study')
 api.add_resource(ImportPersonas, '/import/personas')
 api.add_resource(ImportUserPersonas, '/import/user_personas')
+api.add_resource(ImportLeaderboard, '/import/leaderboard')
+api.add_resource(ImportElementaryLeaderboard, '/import/elementary_leaderboard')
+api.add_resource(ImportSkillSnapshots, '/import/skill_snapshots')

--- a/scripts/db_init.py
+++ b/scripts/db_init.py
@@ -23,24 +23,74 @@ General Process outline:
 
 """
 import shutil
+import subprocess
 import sys
 import os
+from datetime import datetime
 
 # Add the directory containing main.py to the Python path
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 # Import application object
-from main import app, db, generate_data 
+from main import app, db, generate_data
+
+BACKUP_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'instance', 'backups'))
+
+
+def backup_mysql_database():
+    """mysqldump the production database before it is dropped.
+
+    Returns the dump path, or None if the dump could not be taken. This step
+    used to print "Backup not supported for production database" and continue
+    straight into drop_all(), leaving no rollback point at all.
+    """
+    if shutil.which('mysqldump') is None:
+        print("ERROR: mysqldump not found on PATH; cannot back up MySQL.")
+        return None
+
+    os.makedirs(BACKUP_DIR, exist_ok=True)
+    timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
+    db_name = app.config['SQLALCHEMY_DATABASE_NAME']
+    dump_path = os.path.join(BACKUP_DIR, f"{db_name}_{timestamp}.sql")
+
+    cmd = [
+        'mysqldump',
+        f"--host={app.config['DB_ENDPOINT']}",
+        '--port=3306',
+        f"--user={app.config['DB_USERNAME']}",
+        '--single-transaction', '--routines', '--triggers',
+        db_name,
+    ]
+    env = dict(os.environ, MYSQL_PWD=app.config['DB_PASSWORD'])
+
+    print(f"Backing up MySQL database to {dump_path} ...")
+    with open(dump_path, 'w') as out:
+        result = subprocess.run(cmd, stdout=out, stderr=subprocess.PIPE, env=env)
+
+    if result.returncode != 0:
+        print(f"ERROR: mysqldump failed: {result.stderr.decode(errors='replace').strip()[:400]}")
+        if os.path.exists(dump_path):
+            os.remove(dump_path)
+        return None
+
+    size = os.path.getsize(dump_path)
+    print(f"MySQL database backed up to {dump_path} ({size} bytes)")
+    print(f"Roll back with: mysql -h {app.config['DB_ENDPOINT']} "
+          f"-u {app.config['DB_USERNAME']} -p {db_name} < {dump_path}")
+    return dump_path
+
 
 # Backup the old database
 def backup_database(db_uri, backup_uri):
-    """Backup the current database."""
+    """Backup the current database. Returns True when a rollback point exists."""
     if backup_uri:
         db_path = db_uri.replace('sqlite:///', 'instance/')
         backup_path = backup_uri.replace('sqlite:///', 'instance/')
         shutil.copyfile(db_path, backup_path)
         print(f"Database backed up to {backup_path}")
-    else:
-        print("Backup not supported for production database.")
+        return True
+
+    # No backup_uri means production MySQL.
+    return backup_mysql_database() is not None
 
 # Main extraction and loading process
 def main():
@@ -65,8 +115,15 @@ def main():
                     sys.exit(0)
                     
             # Backup the old database
-            backup_database(app.config['SQLALCHEMY_DATABASE_URI'], app.config['SQLALCHEMY_BACKUP_URI'])
-           
+            backed_up = backup_database(
+                app.config['SQLALCHEMY_DATABASE_URI'],
+                app.config['SQLALCHEMY_BACKUP_URI'],
+            )
+            if not backed_up and os.getenv('ALLOW_NO_BACKUP') != 'true':
+                print("\nRefusing to drop the database without a rollback point.")
+                print("Fix the backup above, or set ALLOW_NO_BACKUP=true to override.")
+                sys.exit(1)
+
         except Exception as e:
             print(f"An error occurred: {e}")
             sys.exit(1)

--- a/scripts/db_migrate-prod2sqlite.py
+++ b/scripts/db_migrate-prod2sqlite.py
@@ -34,29 +34,41 @@ from sqlalchemy.exc import OperationalError
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 from main import app, db, initUsers
-from db_utils import authenticate, filter_default_data, BASE_URL, UID, PASSWORD
+from db_utils import (
+    authenticate, filter_default_data, fetch_remote_counts, local_counts,
+    report_reconciliation, BASE_URL, UID, PASSWORD,
+)
 
 # ── Configuration ──────────────────────────────────────────────────────────────
 
 PERSISTENCE_PREFIX = "instance"
 JSON_DATA = f"{PERSISTENCE_PREFIX}/data.json"
 
-# Export endpoints (one per data type)
+# Export endpoints (one per data type).
+# Every table in model/ must appear here -- production runs db_init.py (which
+# does a drop_all) before the data is pushed back, so a table missing from this
+# map is destroyed on production and never restored.
 EXPORT_ENDPOINTS = {
-    'sections':     '/api/export/sections',
-    'users':        '/api/export/users',
-    'topics':       '/api/export/topics',
-    'microblogs':   '/api/export/microblogs',
-    'posts':        '/api/export/posts',
-    'classrooms':   '/api/export/classrooms',
-    'feedback':     '/api/export/feedback',
-    'study':        '/api/export/study',
-    'personas':     '/api/export/personas',
-    'user_personas':'/api/export/user_personas',
+    'sections':               '/api/export/sections',
+    'users':                  '/api/export/users',
+    'topics':                 '/api/export/topics',
+    'microblogs':             '/api/export/microblogs',
+    'posts':                  '/api/export/posts',
+    'classrooms':             '/api/export/classrooms',
+    'feedback':               '/api/export/feedback',
+    'study':                  '/api/export/study',
+    'personas':               '/api/export/personas',
+    'user_personas':          '/api/export/user_personas',
+    'leaderboard':            '/api/export/leaderboard',
+    'elementary_leaderboard': '/api/export/elementary_leaderboard',
+    'skill_snapshots':        '/api/export/skill_snapshots',
 }
 
 # Data types that require paginated fetching
-PAGINATED_TYPES = {'users', 'microblogs', 'posts', 'topics', 'personas', 'user_personas'}
+PAGINATED_TYPES = {
+    'users', 'microblogs', 'posts', 'topics', 'personas', 'user_personas',
+    'leaderboard', 'elementary_leaderboard', 'skill_snapshots',
+}
 
 # ── Database backup / creation helpers ────────────────────────────────────────
 
@@ -243,13 +255,17 @@ def extract_all_data(cookies):
         for dt, err in failed_endpoints:
             print(f"    - {dt}: {err}")
 
-        critical_failed = [dt for dt, _ in failed_endpoints if dt in {'users', 'sections'}]
-        if critical_failed:
+        # Production is wiped by db_init.py before this data is pushed back, so a
+        # partial export is a partial restore. Every endpoint is critical.
+        # Set ALLOW_PARTIAL_EXPORT=true only to inspect a broken endpoint.
+        if os.environ.get('ALLOW_PARTIAL_EXPORT') != 'true':
             return None, {
-                'message': f'Critical endpoints failed: {", ".join(critical_failed)}',
+                'message': f'Export incomplete: {", ".join(dt for dt, _ in failed_endpoints)}',
                 'code': 500,
-                'error': 'Cannot proceed without users and sections data',
+                'error': 'Refusing to continue with a partial export. '
+                         'Fix the endpoint, or set ALLOW_PARTIAL_EXPORT=true to override.',
             }
+        print("  ALLOW_PARTIAL_EXPORT=true - continuing with an INCOMPLETE export")
 
     return all_data, None
 
@@ -319,6 +335,7 @@ def load_users(users_data):
                 ap_exam=user_data.get('ap_exam') or user_data.get('apExam'),
                 school=user_data.get('school'),
                 classes=user_data.get('class') or user_data.get('_class'),
+                game_profile=user_data.get('game_profile') or user_data.get('gameProfile'),
             )
             if user_data.get('email'):
                 user.email = user_data['email']
@@ -623,6 +640,98 @@ def load_user_personas(user_personas_data):
     print(f"  Loaded {loaded} user-persona associations.")
 
 
+def _parse_dt(value):
+    """Parse an ISO-8601 timestamp from an export payload; None if unusable."""
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(str(value).replace('Z', '+00:00'))
+    except (TypeError, ValueError):
+        return None
+
+
+def load_events(events_data, model, label):
+    """Load leaderboard events, preserving their original timestamps."""
+    from model.user import User
+
+    loaded = skipped = 0
+    for event_data in events_data:
+        try:
+            user_uid = event_data.get('userUid')
+            user = User.query.filter_by(_uid=user_uid).first() if user_uid else None
+
+            # user_id is nullable: an event whose author is gone is still history.
+            event = model(
+                payload=event_data.get('payload') or {},
+                user_id=user.id if user else None,
+            )
+            timestamp = _parse_dt(event_data.get('timestamp'))
+            if timestamp:
+                event._timestamp = timestamp
+
+            db.session.add(event)
+            db.session.commit()
+            loaded += 1
+        except Exception as e:
+            db.session.rollback()
+            print(f"  Error loading {label} event: {e}")
+            skipped += 1
+
+    if skipped:
+        print(f"  Skipped {skipped} {label} events")
+    print(f"  Loaded {loaded} {label} events.")
+
+
+def load_leaderboard(events_data):
+    from model.leaderboard import ScoreCounterEvent
+    load_events(events_data, ScoreCounterEvent, 'leaderboard')
+
+
+def load_elementary_leaderboard(events_data):
+    from model.leaderboard import ElementaryLeaderboardEvent
+    load_events(events_data, ElementaryLeaderboardEvent, 'elementary leaderboard')
+
+
+def load_skill_snapshots(snapshots_data):
+    from model.skill_snapshot import SkillSnapshot
+    from model.user import User
+
+    loaded = skipped = 0
+    for snapshot_data in snapshots_data:
+        try:
+            user_uid = snapshot_data.get('userUid')
+            user = User.query.filter_by(_uid=user_uid).first() if user_uid else None
+            if not user:
+                # user_id is NOT NULL, so an orphan snapshot cannot be stored.
+                print(f"  Skipping skill snapshot - no user for uid {user_uid!r}")
+                skipped += 1
+                continue
+
+            snapshot = SkillSnapshot(
+                user_id=user.id,
+                project_name=snapshot_data.get('project_name'),
+                coding_ability=snapshot_data.get('coding_ability'),
+                collaboration=snapshot_data.get('collaboration'),
+                problem_solving=snapshot_data.get('problem_solving'),
+                initiative=snapshot_data.get('initiative'),
+            )
+            snapshot_date = _parse_dt(snapshot_data.get('snapshot_date'))
+            if snapshot_date:
+                snapshot.snapshot_date = snapshot_date
+
+            db.session.add(snapshot)
+            db.session.commit()
+            loaded += 1
+        except Exception as e:
+            db.session.rollback()
+            print(f"  Error loading skill snapshot: {e}")
+            skipped += 1
+
+    if skipped:
+        print(f"  Skipped {skipped} skill snapshots")
+    print(f"  Loaded {loaded} skill snapshots.")
+
+
 def load_all(all_data):
     """Load all data types into the local database in dependency order."""
     user_uid_map = {u.get('id'): u.get('uid') for u in all_data.get('users', []) if u.get('id') and u.get('uid')}
@@ -639,6 +748,11 @@ def load_all(all_data):
         ('classrooms',    lambda: load_classrooms(all_data.get('classrooms', []), user_uid_map)),
         ('feedback',      lambda: load_feedback(all_data.get('feedback', []))),
         ('study',         lambda: load_study(all_data.get('study', []), user_uid_map)),
+        ('leaderboard',   lambda: load_leaderboard(all_data.get('leaderboard', []))),
+        ('elementary_leaderboard',
+                          lambda: load_elementary_leaderboard(all_data.get('elementary_leaderboard', []))),
+        ('skill_snapshots',
+                          lambda: load_skill_snapshots(all_data.get('skill_snapshots', []))),
     ]
 
     for name, loader in loaders:
@@ -716,6 +830,14 @@ def main():
         count = len(data) if isinstance(data, list) else 1
         print(f"  {key}: {count if data else 'No'} records")
 
+    # Count production's own copies of the seed users before they are filtered
+    # out, so the verification step can account for them.
+    from db_utils import DEFAULT_DATA
+    seed_uids = [uid for uid in DEFAULT_DATA['users'] if uid]
+    prod_seed_users = sum(
+        1 for u in (all_data.get('users') or []) if u.get('uid') in seed_uids
+    )
+
     # Filter default seed data
     print("\n=== Filtering out default/test data ===")
     all_data = filter_default_data(all_data)
@@ -741,7 +863,42 @@ def main():
         traceback.print_exc()
         sys.exit(1)
 
-    print("\n=== Database initialized successfully! ===")
+    # Step 4: Verify the local database matches production table by table
+    print("\n=== Step 4: Verifying the pull is complete ===")
+    complete = verify_pull(cookies, prod_seed_users)
+
+    if complete:
+        print("\n=== Database initialized successfully - all tables reconciled ===")
+        return
+
+    print("\n=== WARNING: local database does NOT match production ===")
+    print("Do NOT push this back to production: the missing rows would be lost.")
+    print("Investigate the tables marked MISSING above, then re-run this script.")
+    sys.exit(1)
+
+
+def verify_pull(cookies, prod_seed_users):
+    """Compare production row counts against the freshly loaded local database."""
+    if cookies is None:
+        print("  Skipped: data came from the local JSON fallback, not production.")
+        return True
+
+    remote, err = fetch_remote_counts(cookies)
+    if err:
+        print(f"  Could not fetch production counts: {err}")
+        print("  (/api/export/counts ships with this change - is production running it yet?)")
+        return False
+
+    with app.app_context():
+        local = local_counts()
+
+    # filter_default_data() dropped production's seed users and initUsers()
+    # recreated them locally, so that many users are legitimately "missing".
+    from db_utils import DEFAULT_DATA
+    seeded_locally = len({uid for uid in DEFAULT_DATA['users'] if uid})
+    expected_deficit = {'users': prod_seed_users - seeded_locally}
+
+    return report_reconciliation(remote, local, 'production', 'local', expected_deficit)
 
 
 if __name__ == "__main__":

--- a/scripts/db_restore-sqlite2prod.py
+++ b/scripts/db_restore-sqlite2prod.py
@@ -26,28 +26,39 @@ import requests
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 from main import app, db
-from db_utils import authenticate, filter_default_data, BASE_URL, UID, PASSWORD
+from db_utils import (
+    authenticate, filter_default_data, fetch_remote_counts, local_counts,
+    report_reconciliation, BASE_URL, UID, PASSWORD,
+)
 
 # ── Configuration ──────────────────────────────────────────────────────────────
 
 LOCAL_JSON = "instance/data.json"
 
-# Import endpoints (order matters: sections and users first)
+# Import endpoints (order matters: sections and users first).
+# Must cover every table in model/ -- anything missing here is not restored to
+# production after db_init.py has dropped it.
 IMPORT_ENDPOINTS = {
-    'sections':     '/api/export/import/sections',
-    'users':        '/api/export/import/users',
-    'topics':       '/api/export/import/topics',
-    'microblogs':   '/api/export/import/microblogs',
-    'posts':        '/api/export/import/posts',
-    'classrooms':   '/api/export/import/classrooms',
-    'feedback':     '/api/export/import/feedback',
-    'study':        '/api/export/import/study',
-    'personas':     '/api/export/import/personas',
-    'user_personas':'/api/export/import/user_personas',
+    'sections':               '/api/export/import/sections',
+    'users':                  '/api/export/import/users',
+    'topics':                 '/api/export/import/topics',
+    'microblogs':             '/api/export/import/microblogs',
+    'posts':                  '/api/export/import/posts',
+    'classrooms':             '/api/export/import/classrooms',
+    'feedback':               '/api/export/import/feedback',
+    'study':                  '/api/export/import/study',
+    'personas':               '/api/export/import/personas',
+    'user_personas':          '/api/export/import/user_personas',
+    'leaderboard':            '/api/export/import/leaderboard',
+    'elementary_leaderboard': '/api/export/import/elementary_leaderboard',
+    'skill_snapshots':        '/api/export/import/skill_snapshots',
 }
 
 # Data types large enough to need batched uploads
-LARGE_DATA_TYPES = {'users', 'microblogs', 'posts', 'user_personas', 'personas'}
+LARGE_DATA_TYPES = {
+    'users', 'microblogs', 'posts', 'user_personas', 'personas',
+    'leaderboard', 'elementary_leaderboard', 'skill_snapshots',
+}
 BATCH_SIZE = 50
 
 # ── Local data readers ─────────────────────────────────────────────────────────
@@ -62,6 +73,8 @@ def read_local_data_from_db():
         from model.feedback import Feedback
         from model.study import Study
         from model.persona import Persona, UserPersona
+        from model.leaderboard import ScoreCounterEvent, ElementaryLeaderboardEvent
+        from model.skill_snapshot import SkillSnapshot
 
         with app.app_context():
             print("  Reading ALL data from local database...")
@@ -143,6 +156,26 @@ def read_local_data_from_db():
                     'selectedAt':   up.selected_at.isoformat() if up.selected_at else None,
                 })
             print(f"    Found {len(all_data['user_personas'])} user-persona associations")
+
+            for key, model in (('leaderboard', ScoreCounterEvent),
+                               ('elementary_leaderboard', ElementaryLeaderboardEvent)):
+                all_data[key] = [
+                    {
+                        'id':        event.id,
+                        'userUid':   event.user.uid if event.user else None,
+                        'payload':   event._payload or {},
+                        'timestamp': event._timestamp.isoformat() if event._timestamp else None,
+                    }
+                    for event in model.query.order_by(model.id).all()
+                ]
+                print(f"    Found {len(all_data[key])} {key} events")
+
+            all_data['skill_snapshots'] = []
+            for snapshot in SkillSnapshot.query.order_by(SkillSnapshot.id).all():
+                snapshot_data = snapshot.read()
+                snapshot_data['userUid'] = snapshot.user.uid if snapshot.user else None
+                all_data['skill_snapshots'].append(snapshot_data)
+            print(f"    Found {len(all_data['skill_snapshots'])} skill snapshots")
 
             return all_data, None
 
@@ -227,6 +260,12 @@ def import_all_data(all_data, cookies):
                 print(f"      - {err}")
             if len(combined['errors']) > 3:
                 print(f"      ... and {len(combined['errors']) - 3} more errors")
+            # Batched failures used to be dropped here, so a batched upload could
+            # lose rows and still report overall success.
+            if combined['failed'] > 0:
+                failed_endpoints.append(
+                    (data_type, combined['errors'][0] if combined['errors'] else "unknown")
+                )
 
         else:
             print(f"  Uploading {data_type} ({len(data_list)} records)...", end=" ", flush=True)
@@ -312,7 +351,37 @@ def main():
             print(f"  {icon} {data_type}: {imp} imported, {fail} failed")
 
     print("=" * 60)
-    return 0 if success else 1
+
+    # Step 4: Reconcile local against production, table by table.
+    print("\n=== Step 4: Verifying production matches local ===")
+    reconciled = verify_push(cookies)
+
+    print("=" * 60)
+    if success and reconciled:
+        print("✓ Production reconciled against local - migration complete.")
+        return 0
+
+    if not reconciled:
+        print("✗ Production does NOT match local. Tables marked MISSING above did")
+        print("  not fully transfer. Do not tear down your local copy - it is")
+        print("  currently the only complete copy of that data.")
+    return 1
+
+
+def verify_push(cookies):
+    """Compare the local database against production after the upload."""
+    remote, err = fetch_remote_counts(cookies)
+    if err:
+        print(f"  Could not fetch production counts: {err}")
+        print("  (/api/export/counts ships with this change - is production running it yet?)")
+        return False
+
+    with app.app_context():
+        local = local_counts()
+
+    # Seed users/topics were filtered out of the upload, but production created
+    # its own copies via generate_data(), so those rows exist on both sides.
+    return report_reconciliation(local, remote, 'local', 'production')
 
 
 if __name__ == "__main__":

--- a/scripts/db_utils.py
+++ b/scripts/db_utils.py
@@ -27,12 +27,16 @@ AUTH_URL  = f"{BASE_URL}/api/authenticate"
 UID      = app.config['ADMIN_UID']
 PASSWORD = app.config['ADMIN_PASSWORD']
 
-# Default data created by initUsers / init_posts that must not be duplicated
+# Default data created by initUsers / init_posts that must not be duplicated.
+# This list MUST match the users initUsers() seeds (model/user.py), otherwise a
+# seeded user's production row is pulled but then silently dropped by the loader
+# as "already exists", losing that user's real grade_data/ap_exam/sections.
 DEFAULT_DATA = {
     'users': [
-        app.config.get('ADMIN_UID', 'admin'),
-        app.config.get('DEFAULT_UID', 'user'),
-        'niko',
+        app.config.get('ADMIN_UID'),
+        app.config.get('USER_UID'),
+        app.config.get('TEACHER_UID'),
+        app.config.get('MY_UID'),
     ],
     'sections': ['CSA', 'CSP', 'Robotics', 'CSSE', 'CSH'],
     'topics': [
@@ -71,6 +75,100 @@ def authenticate(uid=None, password=None):
 
 def is_default_user(uid):
     return uid in DEFAULT_DATA['users']
+
+# ── Migration verification ─────────────────────────────────────────────────────
+
+# Every data type the migration scripts move. Must stay in sync with
+# MIGRATED_MODELS in api/data_export_import_api.py.
+MIGRATED_TYPES = [
+    'sections', 'users', 'topics', 'microblogs', 'posts', 'classrooms',
+    'feedback', 'study', 'personas', 'user_personas',
+    'leaderboard', 'elementary_leaderboard', 'skill_snapshots',
+]
+
+
+def fetch_remote_counts(cookies):
+    """Fetch per-table row counts from production. Returns (counts, error)."""
+    headers = {"Content-Type": "application/json", "X-Origin": "client"}
+    try:
+        response = requests.get(
+            f"{BASE_URL}/api/export/counts", headers=headers, cookies=cookies, timeout=120
+        )
+        if response.status_code not in (200, 201):
+            return None, f"HTTP {response.status_code}: {response.text[:200]}"
+        return response.json().get('counts', {}), None
+    except requests.RequestException as e:
+        return None, str(e)
+
+
+def local_counts():
+    """Row counts for every migrated table in the LOCAL database."""
+    from model.user import User, Section, UserSection
+    from model.post import Post
+    from model.microblog import MicroBlog, Topic
+    from model.classroom import Classroom, classroom_student
+    from model.feedback import Feedback
+    from model.study import Study
+    from model.persona import Persona, UserPersona
+    from model.leaderboard import ScoreCounterEvent, ElementaryLeaderboardEvent
+    from model.skill_snapshot import SkillSnapshot
+    from main import db
+
+    models = {
+        'sections': Section, 'users': User, 'topics': Topic, 'microblogs': MicroBlog,
+        'posts': Post, 'classrooms': Classroom, 'feedback': Feedback, 'study': Study,
+        'personas': Persona, 'user_personas': UserPersona,
+        'leaderboard': ScoreCounterEvent,
+        'elementary_leaderboard': ElementaryLeaderboardEvent,
+        'skill_snapshots': SkillSnapshot,
+    }
+    counts = {name: model.query.count() for name, model in models.items()}
+    counts['user_sections'] = UserSection.query.count()
+    counts['classroom_students'] = db.session.query(classroom_student).count()
+    return counts
+
+
+def report_reconciliation(source_counts, target_counts, source_label, target_label,
+                          expected_deficit=None):
+    """Print a source-vs-target table comparison. Returns True when nothing is missing.
+
+    *expected_deficit* maps a data type to the number of rows that are legitimately
+    absent from the target (e.g. seed users filtered out of the transfer).
+    """
+    expected_deficit = expected_deficit or {}
+    complete = True
+
+    width = max(len(k) for k in source_counts) if source_counts else 10
+    print(f"\n  {'table'.ljust(width)}  {source_label:>10}  {target_label:>10}  status")
+    print(f"  {'-' * width}  {'-' * 10}  {'-' * 10}  ------")
+
+    for name in sorted(source_counts):
+        src = source_counts.get(name)
+        tgt = target_counts.get(name)
+
+        if not isinstance(src, int) or not isinstance(tgt, int):
+            print(f"  {name.ljust(width)}  {str(src):>10}  {str(tgt):>10}  UNKNOWN")
+            complete = False
+            continue
+
+        allowed = expected_deficit.get(name, 0)
+        missing = src - tgt - allowed
+
+        if missing > 0:
+            print(f"  {name.ljust(width)}  {src:>10}  {tgt:>10}  MISSING {missing}")
+            complete = False
+        elif missing < 0:
+            print(f"  {name.ljust(width)}  {src:>10}  {tgt:>10}  +{-missing} extra")
+        else:
+            print(f"  {name.ljust(width)}  {src:>10}  {tgt:>10}  ok")
+
+    only_in_source = set(source_counts) - set(target_counts)
+    if only_in_source:
+        print(f"\n  Tables present in {source_label} but absent from {target_label}: "
+              f"{', '.join(sorted(only_in_source))}")
+        complete = False
+
+    return complete
 
 def is_default_section(abbreviation):
     return abbreviation in DEFAULT_DATA['sections']


### PR DESCRIPTION
- Updated .gitignore to exclude user management database files.
- Revised README.md to clarify database management workflow and migration steps.
- Added support for exporting and importing leaderboard events and skill snapshots in data_export_import_api.py.
- Implemented backup functionality for MySQL databases in db_init.py before dropping the database.
- Enhanced db_migrate-prod2sqlite.py to include new data types in export and reconciliation processes.
- Improved db_restore-sqlite2prod.py to verify local data against production after uploads.
- Updated db_utils.py to include functions for fetching remote counts and reporting reconciliation status.