### PR TITLE
flask: Invalidate sessions and JWTs when a user's password changes (1/3 split of #73)

### DIFF
--- a/api/authorize.py
+++ b/api/authorize.py
@@ -63,14 +63,24 @@ def auth_required(roles=None):
                     # Decode the token and retrieve the user data
                     data = jwt.decode(token, current_app.config["SECRET_KEY"], algorithms=["HS256"])
                     user = User.query.filter_by(_uid=data["_uid"]).first()
-                    
+
                     if user is None:
                         return {
                             "message": "Invalid Authentication token!",
                             "data": None,
                             "error": "Unauthorized"
                         }, 401
-                    
+
+                    # Tokens issued before this field existed have no token_version claim
+                    # (treated as 0); reject if it doesn't match the account's current
+                    # value -- i.e. the password has changed since this token was issued.
+                    if data.get("token_version", 0) != (user.token_version or 0):
+                        return {
+                            "message": "Token is no longer valid -- password has changed.",
+                            "data": None,
+                            "error": "Unauthorized"
+                        }, 401
+
                     auth_method = "jwt"
                     # Set the current_user in the global context
                     g.current_user = user

--- a/api/user.py
+++ b/api/user.py
@@ -1,7 +1,7 @@
 import jwt
 from flask import Blueprint, app, request, jsonify, current_app, Response, g
 from flask_restful import Api, Resource # used for REST API building
-from datetime import datetime
+from datetime import datetime, timedelta
 from __init__ import app, db
 from api.authorize import token_required
 from model.user import User
@@ -392,8 +392,16 @@ class UserAPI:
                 # Check if user is found
                 if user:
                     try:
+                        # exp ties the token's server-enforced lifetime to the cookie's
+                        # client-side max_age (previously the token never expired by JWT
+                        # semantics at all). token_version is checked on every request in
+                        # auth_required -- see model/user.py's token_version column comment.
                         token = jwt.encode(
-                            {"_uid": user._uid},
+                            {
+                                "_uid": user._uid,
+                                "token_version": user.token_version,
+                                "exp": datetime.utcnow() + timedelta(seconds=current_app.config["JWT_TOKEN_MAX_AGE"]),
+                            },
                             current_app.config["SECRET_KEY"],
                             algorithm="HS256"
                         )

--- a/main.py
+++ b/main.py
@@ -110,7 +110,17 @@ def unauthorized_callback():
 # register URIs for server pages
 @login_manager.user_loader
 def load_user(user_id):
-    return User.query.get(int(user_id))
+    # user_id is the composite "id:token_version" from User.get_id(). A mismatched
+    # token_version means the session predates a password change on this account --
+    # returning None here tells Flask-Login the session is invalid.
+    try:
+        raw_id, token_version = user_id.split(":", 1)
+    except ValueError:
+        return None
+    user = User.query.get(int(raw_id))
+    if user is None or str(user.token_version) != token_version:
+        return None
+    return user
 
 @app.context_processor
 def inject_user():

--- a/model/user.py
+++ b/model/user.py
@@ -158,6 +158,11 @@ class User(db.Model, UserMixin):
     _class = db.Column(db.JSON, unique=False, nullable=True)
     _school = db.Column(db.String(255), default="Unknown", nullable=True)
     _game_profile = db.Column(db.JSON, unique=False, nullable=True)
+    # Bumped every time the password actually changes (set_password). Embedded in issued
+    # JWTs and in the Flask-Login session id (see get_id) and checked on every request, so
+    # a stolen JWT or session cookie stops working the moment this account's password is
+    # reset, instead of staying valid for the rest of its lifetime.
+    token_version = db.Column(db.Integer, default=0, nullable=False)
 
     # Define many-to-many relationship with Section model through UserSection table
     # Overlaps setting silences SQLAlchemy warnings about multiple relationship paths
@@ -188,9 +193,12 @@ class User(db.Model, UserMixin):
         self._school = school
         self._game_profile = game_profile if game_profile else None
 
-    # UserMixin/Flask-Login requires a get_id method to return the id as a string
+    # UserMixin/Flask-Login requires a get_id method to return the id as a string.
+    # Composite id (id:token_version) so load_user (main.py) can reject a session cookie
+    # whose token_version doesn't match the account's current one -- see token_version
+    # column comment above.
     def get_id(self):
-        return str(self.id)
+        return f"{self.id}:{self.token_version}"
 
     # UserMixin/Flask-Login requires is_authenticated to be defined
     @property
@@ -271,10 +279,16 @@ class User(db.Model, UserMixin):
         """Set password: hash if not already hashed, else set directly."""
         if password and password.startswith("pbkdf2:sha256:"):
             # Already hashed, set directly
-            self._password = password
+            new_hash = password
         else:
             # Not hashed, hash it
-            self._password = generate_password_hash(password, "pbkdf2:sha256", salt_length=10)            
+            new_hash = generate_password_hash(password, "pbkdf2:sha256", salt_length=10)
+
+        # Only bump on an actual change, so idempotent operations (e.g. re-importing the
+        # same hash during a data restore) don't needlessly invalidate live sessions/JWTs.
+        if new_hash != self._password:
+            self.token_version = (self.token_version or 0) + 1
+        self._password = new_hash            
 
     # check password parameter versus stored/encrypted password
     def is_password(self, password):


### PR DESCRIPTION
Splitting #73 into smaller, independently-reviewable PRs across spring/flask/pages. This one covers the **password reset button** side of flask — session/JWT invalidation on password change.

Independent of the other PRs in this stack.

Previously nothing tied an issued JWT or Flask-Login session to a specific password: the JWT had no `exp` claim at all and carried nothing password-derived, and sessions carried a bare user id. A stolen JWT or session cookie kept working indefinitely, surviving a password reset meant to lock an attacker out.

Adds `User.token_version`, bumped in `set_password()` only on an actual hash change. JWTs now carry `token_version` + `exp` and are checked against the account's current value; sessions carry it via a composite `get_id()`, checked in `load_user`.

**Requires a schema change before deploy**: `ALTER TABLE users ADD COLUMN token_version INTEGER NOT NULL DEFAULT 0;`

Original PR: #73